### PR TITLE
Fix missing CapsuleGeometry error by adding polyfill

### DIFF
--- a/maze-electro-girl-fps-advanced/index.html
+++ b/maze-electro-girl-fps-advanced/index.html
@@ -176,6 +176,7 @@
 
     <!-- 스크립트 로드 -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/utils/BufferGeometryUtils.js"></script>
     <!-- 시스템 스크립트들을 GameManager보다 먼저 로드 -->
     <script src="js/PlayerController.js"></script>
     <script src="js/ElectroGun.js"></script>

--- a/maze-electro-girl-fps-advanced/js/PlayerController.js
+++ b/maze-electro-girl-fps-advanced/js/PlayerController.js
@@ -1,6 +1,6 @@
 /**
  * PlayerController: 고급 1인칭 FPS 플레이어 컨트롤러
- * 
+ *
  * 핵심 기능:
  * - 부드러운 1인칭 시점 제어 (마우스 루킹)
  * - 물리 기반 이동 시스템 (관성, 마찰력)
@@ -9,6 +9,32 @@
  * - 피격 및 체력 관리
  * - 발소리 및 움직임 피드백
  */
+
+// Polyfill for THREE.CapsuleGeometry when using older versions of Three.js
+if (!THREE.CapsuleGeometry) {
+    console.warn('THREE.CapsuleGeometry is not available. Applying polyfill.');
+
+    THREE.CapsuleGeometry = function (radius = 1, length = 1, capSegments = 4, radialSegments = 8) {
+        const cylinder = new THREE.CylinderGeometry(radius, radius, length, radialSegments, 1, true);
+        const cap = new THREE.SphereGeometry(radius, radialSegments, capSegments, 0, Math.PI * 2, 0, Math.PI / 2);
+
+        const capTop = cap.clone();
+        capTop.translate(0, length / 2, 0);
+
+        const capBottom = cap.clone();
+        capBottom.rotateX(Math.PI);
+        capBottom.translate(0, -length / 2, 0);
+
+        const geometry = THREE.BufferGeometryUtils.mergeBufferGeometries(
+            [cylinder, capTop, capBottom],
+            false
+        );
+
+        geometry.computeVertexNormals();
+        return geometry;
+    };
+}
+
 class PlayerController {
     constructor(scene, camera, gameManager) {
         this.scene = scene;


### PR DESCRIPTION
## Summary
- add BufferGeometryUtils script to ensure geometry merging utilities are available
- implement CapsuleGeometry polyfill so game runs on three.js r128

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa04972c832d98183c13755c0953